### PR TITLE
Change to readme to reflect credential call that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import YelpApi from 'v3-yelp-api';
 
 const credentials = {
     appId:"App Id from Yelp Developer Console",
-    app: "App Secret from Yelp Developer Console"
+    appSecret: "App Secret from Yelp Developer Console"
 }
 
 const yelp = New YelpApi(credentials)


### PR DESCRIPTION
Rather than leave a message, I wanted to see if this change works for you:

- I changed the `app` credential in the documentation to reflect what the YelpApi Object actually returns. I also noticed the `constructor` in the `index.js` file: 

```  constructor(options) {
    this.credentials = {
      client_id:options.appId,
      client_secret:options.appSecret,
      grant_type:'client_credentials'
    }
  } ```

Thank you for making this wrapper!
